### PR TITLE
PA56: Separate RabbitMQ out as an individual container

### DIFF
--- a/app/services/message_publisher.rb
+++ b/app/services/message_publisher.rb
@@ -2,7 +2,13 @@ require "bunny"
 
 class MessagePublisher
   def self.publish(payload, queue)
-    connection = Bunny.new(hostname: "rabbitmq")
+    connection = Bunny.new(
+      hostname: ENV["DOMAIN"],
+      port: ENV["RABBITMQ_PORT"],
+      user: ENV["RABBITMQ_USER"],
+      password: ENV["RABBITMQ_PASSWORD"],
+      vhost: "/"
+    )
     connection.start
     channel = connection.create_channel
     queue = channel.queue(queue, durable: true)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,14 +46,6 @@ services:
     depends_on:
       - api
 
-  rabbitmq:
-    image: rabbitmq:3.12-management
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    networks:
-      - app-net-dev
-
 volumes:
   db-data-dev:
   bundle-cache:

--- a/docker-compose.rabbitmq.yml
+++ b/docker-compose.rabbitmq.yml
@@ -1,0 +1,12 @@
+services:
+
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+
+volumes:
+  rabbitmq-data:

--- a/spec/services/message_publisher_spec.rb
+++ b/spec/services/message_publisher_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe MessagePublisher do
+  describe ".publish" do
+    let(:payload) { { message: "Hello" } }
+    let(:queue_name) { "test_queue" }
+    let(:mock_connection) { instance_double(Bunny::Session) }
+    let(:mock_channel) { instance_double(Bunny::Channel) }
+    let(:mock_queue) { instance_double(Bunny::Queue) }
+    let(:hmac_secret) { "supersecretkey" }
+
+    before do
+      allow(ENV).to receive(:[]).with("DOMAIN").and_return("localhost")
+      allow(ENV).to receive(:[]).with("RABBITMQ_PORT").and_return("5672")
+      allow(ENV).to receive(:[]).with("RABBITMQ_USER").and_return("guest")
+      allow(ENV).to receive(:[]).with("RABBITMQ_PASSWORD").and_return("guest")
+
+      allow(Bunny).to receive(:new).and_return(mock_connection)
+      allow(mock_connection).to receive(:start)
+      allow(mock_connection).to receive(:create_channel).and_return(mock_channel)
+      allow(mock_connection).to receive(:close)
+
+      allow(mock_channel).to receive(:queue).with(queue_name, durable: true).and_return(mock_queue)
+      allow(mock_queue).to receive(:publish)
+
+      allow(Rails.application).to receive_message_chain(:credentials, :hmac_secret).and_return(hmac_secret)
+    end
+
+    it "connects to RabbitMQ with correct connection parameters" do
+      expect(Bunny).to receive(:new).with(
+        hostname: "localhost",
+        port: "5672",
+        user: "guest",
+        password: "guest",
+        vhost: "/"
+      ).and_return(mock_connection)
+      described_class.publish(payload, queue_name)
+    end
+
+    it "connects, signs, and publishes the message" do
+      json_payload = payload.to_json
+      expected_signature = OpenSSL::HMAC.hexdigest("SHA256", hmac_secret, json_payload)
+      expected_payload = payload.merge(signature: expected_signature).to_json
+
+      described_class.publish(payload, queue_name)
+
+      expect(mock_connection).to have_received(:start)
+      expect(mock_channel).to have_received(:queue).with(queue_name, durable: true)
+      expect(mock_queue).to have_received(:publish).with(expected_payload, persistent: true)
+      expect(mock_connection).to have_received(:close)
+    end
+  end
+end


### PR DESCRIPTION
## 📌 Jira Ticket
https://mohammadalmousawi80.atlassian.net/browse/PA-56

## 📝 Description
Originally, RabbitMQ was built using the same docker-compose file as the web service. As a result, when we bring down the web service using the docker-compose down command, RabbitMQ is also stopped, this is not the desired behavior.

To mitigate this issue, we plan to separate RabbitMQ into its own docker-compose configuration. This way, stopping the web service will not affect RabbitMQ.

## ✅ Checklist
- [x] PR title follows format: `PA123: Description`
- [x] All check pass

## 📸 Screenshots (if applicable)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2ee3f1d3-11dd-431e-bf26-ffbc8738a7c8" />

