### PR TITLE
PA53: Set up production ENV 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,34 +5,50 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_DB: project_ambience_production
+    ports:
+      - "6433:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:
       - app-net
 
-  web:
+  api:
     build:
       context: .
-      dockerfile: Dockerfile
-    depends_on:
-      - db
+      dockerfile: Dockerfile.dev
     ports:
-      - "5090:5090"
-    env_file:
-      - .env
-    environment:
-      RAILS_ENV: production
-      DATABASE_URL: "postgresql://postgres:password@db:5432/project_ambience_production"
-      RAILS_SERVE_STATIC_FILES: true
+      - "7091:3000"
     volumes:
-      - ./storage:/rails/storage
+      - .:/rails
+      - bundle-cache:/usr/local/bundle
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: "postgresql://postgres:password@db:5432/project_ambience_production"
     networks:
       - app-net
-    restart: unless-stopped
-    command: ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "5090"]
+    depends_on:
+      - db
+    command: ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile.dev
+    ports:
+      - "7090:3000"
+    volumes:
+      - ./client:/app
+      - /app/node_modules
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+    networks:
+      - app-net
+    depends_on:
+      - api
 
 volumes:
   db-data:
+  bundle-cache:
 
 networks:
   app-net:


### PR DESCRIPTION
## 📌 Jira Ticket
https://mohammadalmousawi80.atlassian.net/browse/PA-53

## 📝 Description

Starting next week, real users (MSc Computer Science students) will begin using our application. They will primarily interact with the Model Download feature and the Model Catalog page.

To support this, we are splitting the application into two environments:

Port 5090 for development/staging (STG)

Port 7090 for production (PROD)

Important: We will not make any changes, take down, or deploy anything to the production environment (7090) without team consent and an official release note.

## ✅ Checklist
- [x] PR title follows format: `PA123: Description`
- [x] All check pass

## 📸 Screenshots (if applicable)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3f58a513-f18e-457f-bc7e-0fd2ea9df8d9" />

