### PR TITLE
PA82: Delete "signature" in inference message

### DIFF
--- a/app/services/message_publisher.rb
+++ b/app/services/message_publisher.rb
@@ -12,11 +12,8 @@ class MessagePublisher
     connection.start
     channel = connection.create_channel
     queue = channel.queue(queue, durable: true)
-    secret = Rails.application.credentials.hmac_secret
-    json_payload_to_sign = payload.to_json
-    signature = OpenSSL::HMAC.hexdigest("SHA256", secret, json_payload_to_sign)
-    final_payload = payload.merge(signature: signature).to_json
-    queue.publish(final_payload, persistent: true)
+    json_payload = payload.to_json
+    queue.publish(json_payload, persistent: true)
     connection.close
   end
 end


### PR DESCRIPTION
## 📌 Jira Ticket
https://mohammadalmousawi80.atlassian.net/browse/PA-82

## 📝 Description
- Removed HMAC signature in the inference message
- Updated RSpec test accordingly


## ✅ Checklist
- [x] PR title follows format: `PA123: Description`
- [x] All check pass

## 📸 Screenshots (if applicable)
<img width="1069" height="992" alt="Screenshot 2025-07-14 at 11 47 21 AM" src="https://github.com/user-attachments/assets/ad737a27-4f80-4cb0-8927-19bee5e1fdd1" />
