### PR TITLE
PA85: include model's speciality in inference message

### DIFF
--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -23,7 +23,8 @@ class Api::MessagesController < Api::ApplicationController
         file_url: @conversation.file_url,
         input: input_history,
         base_model_path: @conversation.ai_model.path,
-        adapter_path: @conversation.ai_model.adapter_path
+        adapter_path: @conversation.ai_model.adapter_path,
+        speciality: @conversation.ai_model.speciality
       }, ENV["USER_PROMPT_QUEUE_NAME"])
 
       @conversation.awaiting_feedback!

--- a/app/controllers/api/model_fine_tune_requests_controller.rb
+++ b/app/controllers/api/model_fine_tune_requests_controller.rb
@@ -93,7 +93,8 @@ class Api::ModelFineTuneRequestsController < Api::ApplicationController
       base_model_id: model_fine_tune_request.ai_model_id,
       path: model_fine_tune_request.ai_model.path,
       adapter_path: adapter_path,
-      keywords: model_fine_tune_request.ai_model.keywords
+      keywords: model_fine_tune_request.ai_model.keywords,
+      speciality: model_fine_tune_request.task
     )
 
     ai_model

--- a/db/migrate/20250718125629_add_speciality_to_ai_models.rb
+++ b/db/migrate/20250718125629_add_speciality_to_ai_models.rb
@@ -1,0 +1,5 @@
+class AddSpecialityToAiModels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ai_models, :speciality, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_14_130815) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_18_125629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_14_130815) do
     t.bigint "base_model_id"
     t.string "path"
     t.string "adapter_path"
+    t.string "speciality"
     t.index ["base_model_id"], name: "index_ai_models_on_base_model_id"
     t.index ["clinician_type_id"], name: "index_ai_models_on_clinician_type_id"
   end

--- a/spec/requests/message_spec.rb
+++ b/spec/requests/message_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "MessageRequests", type: :request do
-  let!(:ai_model) { create(:ai_model, path: "some path", adapter_path: "some adapter path") }
+  let!(:ai_model) { create(:ai_model, path: "some path", adapter_path: "some adapter path", speciality: "summarise") }
   let!(:conversation) { create(:conversation, ai_model: ai_model) }
 
   describe "POST /api/conversations/:conversation_id/messages" do
@@ -47,7 +47,8 @@ RSpec.describe "MessageRequests", type: :request do
         file_url: conversation.file_url,
         input: expected_input_history,
         base_model_path: "some path",
-        adapter_path: "some adapter path"
+        adapter_path: "some adapter path",
+        speciality: "summarise"
       }
       expect(MessagePublisher).to have_received(:publish).with(expected_payload, "user_prompts")
     end


### PR DESCRIPTION
## 📌 Jira Ticket
https://mohammadalmousawi80.atlassian.net/browse/PA-85

## 📝 Description
requirement from @malmousawi to include model speciality in inference message. This speciality will be use in prompt engineering service

* Note that for base model, speciality will always be null

## ✅ Checklist
- [x] PR title follows format: `PA123: Description`
- [x] All check pass

## 📸 Screenshots (if applicable)

<img width="1090" height="250" alt="image" src="https://github.com/user-attachments/assets/7eda3dbf-c60f-428d-96fc-f5fabade29b7" />

